### PR TITLE
Fix #3254 Valid message displayed when searched caption is not found

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/categories/SearchCategoryFragment.java
@@ -217,7 +217,7 @@ public class SearchCategoryFragment extends CommonsDaggerSupportFragment {
     private void initErrorView() {
         progressBar.setVisibility(GONE);
         categoriesNotFoundView.setVisibility(VISIBLE);
-        categoriesNotFoundView.setText(getString(R.string.categories_not_found));
+        categoriesNotFoundView.setText(getString(R.string.categories_not_found,query));
     }
 
     /**

--- a/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/explore/images/SearchImageFragment.java
@@ -251,7 +251,7 @@ public class SearchImageFragment extends CommonsDaggerSupportFragment {
     private void initErrorView() {
         progressBar.setVisibility(GONE);
         imagesNotFoundView.setVisibility(VISIBLE);
-        imagesNotFoundView.setText(getString(R.string.images_not_found));
+        imagesNotFoundView.setText(getString(R.string.images_not_found,query));
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 14 14:54:52 EDT 2019
+#Thu Dec 26 14:27:31 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
**Description (required)**

When searching for a caption in the explore section, if no results found for the searched caption then an erroneous message is displayed under the "Media" and "Categories". Refer Issue #3254

**Tests performed (required)**

Tested betaDebug on Android 9